### PR TITLE
refresh window content to prevent blank splash

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func startBreakTimer() {
 	// log.Println("start break ticker")
 	disableSystrayTimer()
 	a.SendNotification(fyne.NewNotification("Start Break Timer", "Start Break Timer"))
+	w.Content().Refresh()
 	w.Show()
 
 	duration := breakSeconds
@@ -187,6 +188,7 @@ func startBreakTimer() {
 		timerText.Refresh()
 		duration--
 		time.Sleep(time.Second)
+		w.Content().Refresh()
 	}
 }
 


### PR DESCRIPTION
When playing around with this I noticed that on repeat Show()ing of the splash screen everything was blank. This resolves that issue for me. (Also thanks to @andydotxyz for the pointers :D)